### PR TITLE
feat: show other tutors and species-based fallback images

### DIFF
--- a/src/app/(app)/(logged-in)/carteira/pet/[slug]/page.tsx
+++ b/src/app/(app)/(logged-in)/carteira/pet/[slug]/page.tsx
@@ -55,7 +55,9 @@ export default async function PetPage({ params }: PetPageProps) {
     return <PetNotFound />
   }
 
-  const uniquePetData = uniquePet.data
+  const uniquePetData = uniquePet.data as typeof uniquePet.data & {
+    outros_tutores?: { cpf: string; nome: string; email: string }[]
+  }
 
   const petHasMicrochip = !!uniquePetData?.microchip_numero
 
@@ -68,6 +70,7 @@ export default async function PetPage({ params }: PetPageProps) {
       petClinicName={petClinicName}
       petHasMicrochip={petHasMicrochip}
       tutorInfoObj={userInfoObj}
+      outrosTutores={uniquePetData?.outros_tutores}
     />
   )
 }

--- a/src/app/(app)/(logged-in)/carteira/pet/[slug]/pet-client-page.tsx
+++ b/src/app/(app)/(logged-in)/carteira/pet/[slug]/pet-client-page.tsx
@@ -18,6 +18,11 @@ interface PetClientPageProps {
     phone: string
     email: string
   }
+  outrosTutores?: {
+    cpf: string
+    nome: string
+    email: string
+  }[]
 }
 
 const SMPDA_ATENDIMENTO_URL =
@@ -33,6 +38,7 @@ export function PetClientPage({
   petClinicName,
   petHasMicrochip,
   tutorInfoObj,
+  outrosTutores,
 }: PetClientPageProps) {
   const showCastracao = pet.indicador_castrado !== true
   const showMicrochipActions = !petHasMicrochip
@@ -148,6 +154,21 @@ export function PetClientPage({
           phone={tutorInfoObj?.phone ?? ''}
           email={tutorInfoObj?.email ?? ''}
         />
+        {outrosTutores &&
+          outrosTutores.length > 0 &&
+          outrosTutores.map(tutor => (
+            <div key={tutor.cpf}>
+              <div className="px-4">
+                <div className="bg-border h-px" />
+              </div>
+              <TutorInfo
+                name={tutor.nome}
+                cpf={tutor.cpf}
+                phone=""
+                email={tutor.email}
+              />
+            </div>
+          ))}
       </div>
     </div>
   )

--- a/src/app/(app)/(logged-in)/carteira/pet/components/tutor-info.tsx
+++ b/src/app/(app)/(logged-in)/carteira/pet/components/tutor-info.tsx
@@ -13,30 +13,38 @@ export function TutorInfo({ name, cpf, phone, email }: TutorInfoProps) {
   return (
     <div className="w-full">
       <div className="flex flex-col gap-1 p-4">
-        <div className="text-sm">
-          <span className="text-foreground-light leading-5 dark:text-foreground-light/70">
-            Nome{' '}
-          </span>
-          <span className="text-foreground leading-5">{name}</span>
-        </div>
-        <div className="text-sm">
-          <span className="text-foreground-light leading-5 dark:text-foreground-light/70">
-            CPF{' '}
-          </span>
-          <span className="text-foreground leading-5">{formatCpf(cpf)}</span>
-        </div>
-        <div className="text-sm">
-          <span className="text-foreground-light leading-5 dark:text-foreground-light/70">
-            Telefone{' '}
-          </span>
-          <span className="text-foreground leading-5">{phone}</span>
-        </div>
-        <div className="text-sm">
-          <span className="text-foreground-light leading-5 dark:text-foreground-light/70">
-            E-mail{' '}
-          </span>
-          <span className="text-foreground leading-5">{email}</span>
-        </div>
+        {name && (
+          <div className="text-sm">
+            <span className="text-foreground-light leading-5 dark:text-foreground-light/70">
+              Nome{' '}
+            </span>
+            <span className="text-foreground leading-5">{name}</span>
+          </div>
+        )}
+        {cpf && (
+          <div className="text-sm">
+            <span className="text-foreground-light leading-5 dark:text-foreground-light/70">
+              CPF{' '}
+            </span>
+            <span className="text-foreground leading-5">{formatCpf(cpf)}</span>
+          </div>
+        )}
+        {phone && (
+          <div className="text-sm">
+            <span className="text-foreground-light leading-5 dark:text-foreground-light/70">
+              Telefone{' '}
+            </span>
+            <span className="text-foreground leading-5">{phone}</span>
+          </div>
+        )}
+        {email && (
+          <div className="text-sm">
+            <span className="text-foreground-light leading-5 dark:text-foreground-light/70">
+              E-mail{' '}
+            </span>
+            <span className="text-foreground leading-5">{email}</span>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/ui/custom/pet-card-front-content.tsx
+++ b/src/components/ui/custom/pet-card-front-content.tsx
@@ -14,18 +14,21 @@ interface PetCardFrontContentProps {
   petImageUrl?: string
 }
 
+const FALLBACK_CANINE =
+  'https://storage.googleapis.com/rj-escritorio-dev-public/superapp/png/avatars/avatar9.png'
+const FALLBACK_FELINE =
+  'https://storage.googleapis.com/rj-escritorio-dev-public/superapp/png/avatars/avatar11.png'
+
 interface FallbackImageProps {
   src?: string
   alt?: string
   width?: number
   height?: number
   className?: string
+  fallback: string
 }
 
-const FallbackImage = ({ src, alt, ...props }: FallbackImageProps) => {
-  const fallback =
-    'https://storage.googleapis.com/rj-escritorio-dev-public/superapp/png/avatars/avatar9.png'
-
+const FallbackImage = ({ src, alt, fallback, ...props }: FallbackImageProps) => {
   const [imgSrc, setImgSrc] = useState(src)
 
   return createElement(Image, {
@@ -65,6 +68,7 @@ export function PetCardFrontContent({
             width={80}
             height={80}
             className="w-full h-full object-cover"
+            fallback={species.toUpperCase() === 'FELINA' ? FALLBACK_FELINE : FALLBACK_CANINE}
           />
         </div>
 


### PR DESCRIPTION
- Add other tutors section below the main tutor on the pet page, separated by a thin divider aligned to the content padding
- Hide empty fields in TutorInfo (name, CPF, phone, email)
- Set fallback image by species: feline uses avatar11, canine uses avatar9