### PR TITLE
ci: add Claude Code agent and CDN cache invalidation to deploys

### DIFF
--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -1,0 +1,51 @@
+name: Claude Code Agent
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude:
+    if: |
+      contains(github.event.comment.body, '@claude') ||
+      contains(github.event.issue.body, '@claude') ||
+      contains(github.event.pull_request.body, '@claude')
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CLAUDE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Setup GCP credentials
+        run: |
+          echo '${{ secrets.GCP_SA_KEY }}' > /tmp/gcp-key.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-key.json" >> $GITHUB_ENV
+          echo "ANTHROPIC_VERTEX_PROJECT_ID=${{ secrets.GCP_PROJECT_ID }}" >> $GITHUB_ENV
+          echo "CLOUD_ML_REGION=us-east5" >> $GITHUB_ENV
+
+      - uses: anthropics/claude-code-action@beta
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          use_vertex: "true"
+          model: "claude-sonnet-4-6@default"
+          allowed_tools: "Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr ready:*)"

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -215,6 +215,17 @@ jobs:
           kubectl argo rollouts promote app -n app
           kubectl argo rollouts status app -n app --timeout=5m
 
+      - name: Invalidate CDN Cache
+        if: steps.check-k8s-only.outputs.k8s_only != 'true' && success()
+        run: |
+          echo "Invalidating Cloud CDN cache for staging..."
+          gcloud compute url-maps invalidate-cdn-cache \
+            k8s2-um-xr1ivql5-istio-system-ingress-istio-app-dluxmjag \
+            --path "/*" \
+            --project=rj-superapp-staging \
+            --global
+          echo "✅ CDN cache invalidated"
+
       - name: Rollback on Failure
         if: steps.check-k8s-only.outputs.k8s_only != 'true' && failure()
         run: |

--- a/.github/workflows/release-production.yaml
+++ b/.github/workflows/release-production.yaml
@@ -172,6 +172,17 @@ jobs:
             sleep 30
           done
 
+      - name: Invalidate CDN Cache
+        if: success()
+        run: |
+          echo "Invalidating Cloud CDN cache for production..."
+          gcloud compute url-maps invalidate-cdn-cache \
+            k8s2-um-ikae1jxm-istio-system-ingress-istio-app-yo7cj2t9 \
+            --path "/*" \
+            --project=rj-superapp \
+            --global
+          echo "✅ CDN cache invalidated"
+
       - name: Create deployment summary
         if: always()
         run: |


### PR DESCRIPTION
## O que esse PR faz

### Claude Code Agent
- Adiciona `claude-agent.yml` para habilitar o @claude no repo do superapp, igualmente ao que já existe no `app-go-api`
- Requer que os secrets `CLAUDE_GITHUB_APP_ID`, `CLAUDE_GITHUB_APP_PRIVATE_KEY` e `GCP_SA_KEY` sejam configurados no repo (os mesmos do app-go-api)

### Invalidação de cache CDN
- Adiciona etapa de invalidação do Cloud CDN após a promoção do rollout blue-green em **staging** (`rj-superapp-staging`)
- Adiciona etapa de invalidação do Cloud CDN após o rollout canary em **produção** (`rj-superapp`)
- Ambas rodam somente em caso de sucesso do deploy