### PR TITLE
fix(ci): add thread_name to Discord payloads for forum channel support

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -283,7 +283,6 @@ jobs:
 
           DISCORD_PAYLOAD=$(cat <<EOF
           {
-            "thread_name": "${STATUS_EMOJI} Staging · ${SHORT_HASH} · ${STATUS_TEXT}",
             "embeds": [{
               "title": "${STATUS_EMOJI} Staging Deployment ${STATUS_TEXT}",
               "description": "${DESCRIPTION}",
@@ -321,4 +320,4 @@ jobs:
 
           curl -H "Content-Type: application/json" \
                -d "$DISCORD_PAYLOAD" \
-               "$DISCORD_WEBHOOK"
+               "$DISCORD_WEBHOOK?thread_id=1465648387566338140"

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -283,6 +283,7 @@ jobs:
 
           DISCORD_PAYLOAD=$(cat <<EOF
           {
+            "thread_name": "${STATUS_EMOJI} Staging · ${SHORT_HASH} · ${STATUS_TEXT}",
             "embeds": [{
               "title": "${STATUS_EMOJI} Staging Deployment ${STATUS_TEXT}",
               "description": "${DESCRIPTION}",

--- a/.github/workflows/release-production.yaml
+++ b/.github/workflows/release-production.yaml
@@ -245,7 +245,6 @@ jobs:
 
           DISCORD_PAYLOAD=$(cat <<EOF
           {
-            "thread_name": "${STATUS_EMOJI} Production · ${VERSION} · ${STATUS_TEXT}",
             "content": "<@&903644455582695494>",
             "embeds": [{
               "title": "${STATUS_EMOJI} Production Release ${STATUS_TEXT}",
@@ -294,4 +293,4 @@ jobs:
 
           curl -H "Content-Type: application/json" \
                -d "$DISCORD_PAYLOAD" \
-               "$DISCORD_WEBHOOK"
+               "$DISCORD_WEBHOOK?thread_id=1465648387566338140"

--- a/.github/workflows/release-production.yaml
+++ b/.github/workflows/release-production.yaml
@@ -245,6 +245,7 @@ jobs:
 
           DISCORD_PAYLOAD=$(cat <<EOF
           {
+            "thread_name": "${STATUS_EMOJI} Production · ${VERSION} · ${STATUS_TEXT}",
             "content": "<@&903644455582695494>",
             "embeds": [{
               "title": "${STATUS_EMOJI} Production Release ${STATUS_TEXT}",


### PR DESCRIPTION
O canal 'Notificações de deploy' é um **forum channel** do Discord, que exige `thread_name` ou `thread_id` no payload do webhook.

Adiciona `thread_name` dinâmico em ambos os workflows:
- **Staging**: `✅ Staging · abc1234 · Succeeded`
- **Production**: `✅ Production · v1.2.3 · Successful`