### PR TITLE
fix(k8s/prod): corrige endereço do Prometheus no AnalysisTemplate

### DIFF
--- a/k8s/prod/resources.yaml
+++ b/k8s/prod/resources.yaml
@@ -196,7 +196,7 @@ spec:
       failureLimit: 5
       provider:
         prometheus:
-          address: http://prometheus.istio-system.svc.cluster.local:9090
+          address: http://prometheus-server.istio-system.svc.cluster.local:9090
           query: |
             (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}",response_code!~"5.."}[2m])) or vector(0)) / (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}"}[2m])) > 0) or vector(1)
     - name: error-rate
@@ -205,6 +205,6 @@ spec:
       failureLimit: 5
       provider:
         prometheus:
-          address: http://prometheus.istio-system.svc.cluster.local:9090
+          address: http://prometheus-server.istio-system.svc.cluster.local:9090
           query: |
             (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}",response_code=~"5.."}[2m])) or vector(0)) / (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}"}[2m])) > 0) or vector(0)


### PR DESCRIPTION
## Problema

O deploy da v1.2.2 para prod falhou no step `Monitor Rollout`. O AnalysisTemplate tentava conectar no Prometheus em:

```
http://prometheus.istio-system.svc.cluster.local:9090
```

Mas em prod o serviço se chama `prometheus-server`, não `prometheus`. O DNS não resolvia, causando 5 `consecutiveErrors` e o abort automático do canary rollout.

```
no such host: prometheus.istio-system.svc.cluster.local
```

**Prod não foi afetada** — o stable continuou servindo 100% do tráfego, o canary abortou com 0%.

## Fix

Corrige o `address` nas duas métricas do `AnalysisTemplate` (`success-rate` e `error-rate`):

```
http://prometheus-server.istio-system.svc.cluster.local:9090
```

## Próximo passo

Após merge, re-triggar a release v1.2.2 para prod.