### PR TITLE
fix: usa script nativo para rio-queue (data-* attrs no HTML inicial)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic'
 
 import { LoginEventTracker } from '@/app/components/login-event-tracker'
 import { HandTalkPlugin } from '@/components/hand-talk-plugin'
-import { QueueGate } from '@/components/queue-gate'
+
 import { PWAProvider } from '@/providers/pwa-provider'
 import { ThemeColorMeta } from '@/providers/theme-color-meta'
 import { ThemeProvider } from '@/providers/theme-provider'
@@ -69,14 +69,16 @@ export default async function RootLayout({
             nonce={nonce}
           />
         )}
-        {process.env.NEXT_PUBLIC_RIO_QUEUE_URL && process.env.NEXT_PUBLIC_RIO_QUEUE_API_URL && (
-          <QueueGate
-            customer="prefeiturario"
-            queue="superapp"
-            scriptUrl={process.env.NEXT_PUBLIC_RIO_QUEUE_URL}
-            apiUrl={process.env.NEXT_PUBLIC_RIO_QUEUE_API_URL}
-          />
-        )}
+        {process.env.NEXT_PUBLIC_RIO_QUEUE_URL &&
+          process.env.NEXT_PUBLIC_RIO_QUEUE_API_URL && (
+            <script
+              src={`${process.env.NEXT_PUBLIC_RIO_QUEUE_URL}/rio-queue.min.js`}
+              data-n-c="prefeiturario"
+              data-n-e="superapp"
+              data-n-url={process.env.NEXT_PUBLIC_RIO_QUEUE_API_URL}
+              async
+            />
+          )}
       </head>
       <body
         className={`${dmSans.className} antialiased`}


### PR DESCRIPTION
Remove QueueGate (next/script afterInteractive) e substitui por script nativo no Server Component. Garante que data-n-c, data-n-e e data-n-url ficam no HTML inicial para que document.currentScript.dataset funcione corretamente no rio-queue.min.js.