### PR TITLE
fix: adiciona nonce ao script do rio-queue para passar no CSP com strict-dynamic

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -76,6 +76,7 @@ export default async function RootLayout({
               data-n-c="prefeiturario"
               data-n-e="superapp"
               data-n-url={process.env.NEXT_PUBLIC_RIO_QUEUE_API_URL}
+              nonce={nonce}
               async
             />
           )}


### PR DESCRIPTION
Com 'strict-dynamic' no script-src, host allowlisting é desabilitado — adicionar storage.googleapis.com não basta. O nonce valida o script diretamente, permitindo que ele passe pelo CSP.