### PR TITLE
fix(oportunidades): redirect login back to current tab instead of home

### DIFF
--- a/src/app/components/courses/courses-header-client.tsx
+++ b/src/app/components/courses/courses-header-client.tsx
@@ -11,9 +11,11 @@ import { buildAuthUrl } from '@/constants/url'
 import { useAuthHeader } from '@/providers/auth-header-provider'
 import Image from 'next/image'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 
 export function CoursesHeaderClient() {
   const { data, isLoading } = useAuthHeader()
+  const pathname = usePathname()
 
   return (
     <header className="fixed top-0 left-0 w-full z-50 bg-background text-foreground px-4 py-3">
@@ -66,7 +68,10 @@ export function CoursesHeaderClient() {
               </Link>
             </div>
           ) : (
-            <Link href={buildAuthUrl('/')} className="flex items-center gap-2">
+            <Link
+              href={buildAuthUrl(pathname)}
+              className="flex items-center gap-2"
+            >
               <span className="text-sm font-normal text-muted-foreground">
                 Login
               </span>

--- a/src/app/components/empregos/empregos-header-client.tsx
+++ b/src/app/components/empregos/empregos-header-client.tsx
@@ -11,9 +11,11 @@ import { buildAuthUrl } from '@/constants/url'
 import { useAuthHeader } from '@/providers/auth-header-provider'
 import Image from 'next/image'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 
 export function EmpregosHeaderClient() {
   const { data, isLoading } = useAuthHeader()
+  const pathname = usePathname()
 
   return (
     <header className="fixed top-0 left-0 w-full z-50 bg-background text-foreground px-4 py-3">
@@ -66,7 +68,10 @@ export function EmpregosHeaderClient() {
               </Link>
             </div>
           ) : (
-            <Link href={buildAuthUrl('/')} className="flex items-center gap-2">
+            <Link
+              href={buildAuthUrl(pathname)}
+              className="flex items-center gap-2"
+            >
               <span className="text-sm font-normal text-muted-foreground">
                 Login
               </span>

--- a/src/app/components/mei/mei-header-client.tsx
+++ b/src/app/components/mei/mei-header-client.tsx
@@ -11,9 +11,11 @@ import { buildAuthUrl } from '@/constants/url'
 import { useAuthHeader } from '@/providers/auth-header-provider'
 import Image from 'next/image'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 
 export function MeiHeaderClient() {
   const { data, isLoading } = useAuthHeader()
+  const pathname = usePathname()
 
   return (
     <header className="fixed top-0 left-0 w-full z-50 bg-background text-foreground px-4 py-3">
@@ -66,7 +68,10 @@ export function MeiHeaderClient() {
               </Link>
             </div>
           ) : (
-            <Link href={buildAuthUrl('/')} className="flex items-center gap-2">
+            <Link
+              href={buildAuthUrl(pathname)}
+              className="flex items-center gap-2"
+            >
               <span className="text-sm font-normal text-muted-foreground">
                 Login
               </span>


### PR DESCRIPTION
Use usePathname() in all three oportunidades headers so that clicking login from cursos, mei, or trabalho returns the user to that same tab after authentication instead of always landing on /.