### PR TITLE
hotfix(cursos): corrige pulo de slides no fluxo de inscrição no mobile

### DIFF
--- a/src/app/(app)/(logged-in-out)/servicos/(servicos)/cursos/[slug]/trocar-turma/components/change-schedule-client.tsx
+++ b/src/app/(app)/(logged-in-out)/servicos/(servicos)/cursos/[slug]/trocar-turma/components/change-schedule-client.tsx
@@ -330,6 +330,7 @@ export function ChangeScheduleClient({
                 slides={slides}
                 onSlideChange={index => setCurrentIndex(index)}
                 showPagination={currentSlide?.showPagination !== false}
+                currentIndex={currentIndex}
               />
             </div>
           )}

--- a/src/app/(app)/(logged-in-out)/servicos/(servicos)/cursos/confirmar-informacoes/components/confirm-inscription-client.tsx
+++ b/src/app/(app)/(logged-in-out)/servicos/(servicos)/cursos/confirmar-informacoes/components/confirm-inscription-client.tsx
@@ -858,6 +858,8 @@ export function ConfirmInscriptionClient({
                 slides={slides}
                 onSlideChange={index => setCurrentIndex(index)}
                 showPagination={currentSlide?.showPagination !== false}
+                currentIndex={currentIndex}
+                onNext={handleNext}
               />
             </div>
           )}

--- a/src/app/(app)/(logged-in-out)/servicos/(servicos)/cursos/confirmar-informacoes/components/confirm-inscription-slider.tsx
+++ b/src/app/(app)/(logged-in-out)/servicos/(servicos)/cursos/confirmar-informacoes/components/confirm-inscription-slider.tsx
@@ -9,124 +9,155 @@ interface ConfirmInscriptionSliderProps {
   slides: SlideData[]
   onSlideChange: (index: number) => void
   showPagination?: boolean
+  currentIndex: number
+  onNext?: () => void
 }
 
 export const ConfirmInscriptionSlider = forwardRef<
   SwiperRef,
   ConfirmInscriptionSliderProps
->(({ slides, onSlideChange, showPagination = true }, ref) => {
-  /* --Pagination Bullets Positioning--
+>(
+  (
+    { slides, onSlideChange, showPagination = true, currentIndex, onNext },
+    ref
+  ) => {
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== 'Enter' || !onNext) return
+      const target = e.target as HTMLElement
+      const tag = target.tagName.toLowerCase()
+      // Only intercept Enter on text inputs and textareas — radio/checkbox have
+      // their own native Enter behaviour and should not trigger slide advance
+      if (tag === 'input' || tag === 'textarea') {
+        e.preventDefault()
+        onNext()
+      }
+    }
+    /* --Pagination Bullets Positioning--
      - Adjust the position of pagination bullets based on the active slide title
      - This effect ensures that the pagination bullets are positioned below the active slide title */
-  useEffect(() => {
-    if (!showPagination) return
+    useEffect(() => {
+      if (!showPagination) return
 
-    const updatePaginationPosition = () => {
-      // Procura primeiro pelo container de título (custom fields com scroll)
-      const customFieldContainer = document.querySelector(
-        '.course__confirm-user-info__slider .swiper-slide-active [data-slide-title-container]'
-      ) as HTMLElement | null
-
-      let titleElement = customFieldContainer
-
-      // Se não encontrar, usa h2 diretamente (slides normais)
-      if (!titleElement) {
-        titleElement = document.querySelector(
-          '.course__confirm-user-info__slider .swiper-slide-active h2'
+      const updatePaginationPosition = () => {
+        // Procura primeiro pelo container de título (custom fields com scroll)
+        const customFieldContainer = document.querySelector(
+          '.course__confirm-user-info__slider .swiper-slide-active [data-slide-title-container]'
         ) as HTMLElement | null
-      }
 
-      const paginationEl = document.querySelector(
-        '.course__confirm-user-info__slider .swiper-pagination'
-      ) as HTMLElement | null
+        let titleElement = customFieldContainer
 
-      if (titleElement && paginationEl) {
-        const offset = customFieldContainer ? -12 : 16
-        const newTop =
-          titleElement.offsetTop + titleElement.offsetHeight + offset
-        paginationEl.style.top = `${newTop}px`
-      }
-    }
+        // Se não encontrar, usa h2 diretamente (slides normais)
+        if (!titleElement) {
+          titleElement = document.querySelector(
+            '.course__confirm-user-info__slider .swiper-slide-active h2'
+          ) as HTMLElement | null
+        }
 
-    let resizeObserver: ResizeObserver | null = null
-
-    const observeActiveTitle = () => {
-      // Procura primeiro pelo container de título (custom fields com scroll)
-      let titleElement = document.querySelector(
-        '.course__confirm-user-info__slider .swiper-slide-active [data-slide-title-container]'
-      ) as HTMLElement | null
-
-      // Se não encontrar, usa h2 diretamente (slides normais)
-      if (!titleElement) {
-        titleElement = document.querySelector(
-          '.course__confirm-user-info__slider .swiper-slide-active h2'
+        const paginationEl = document.querySelector(
+          '.course__confirm-user-info__slider .swiper-pagination'
         ) as HTMLElement | null
+
+        if (titleElement && paginationEl) {
+          const offset = customFieldContainer ? -12 : 16
+          const newTop =
+            titleElement.offsetTop + titleElement.offsetHeight + offset
+          paginationEl.style.top = `${newTop}px`
+        }
       }
 
-      resizeObserver?.disconnect()
-      if (titleElement) {
-        resizeObserver = new ResizeObserver(updatePaginationPosition)
-        resizeObserver.observe(titleElement)
+      let resizeObserver: ResizeObserver | null = null
+
+      const observeActiveTitle = () => {
+        // Procura primeiro pelo container de título (custom fields com scroll)
+        let titleElement = document.querySelector(
+          '.course__confirm-user-info__slider .swiper-slide-active [data-slide-title-container]'
+        ) as HTMLElement | null
+
+        // Se não encontrar, usa h2 diretamente (slides normais)
+        if (!titleElement) {
+          titleElement = document.querySelector(
+            '.course__confirm-user-info__slider .swiper-slide-active h2'
+          ) as HTMLElement | null
+        }
+
+        resizeObserver?.disconnect()
+        if (titleElement) {
+          resizeObserver = new ResizeObserver(updatePaginationPosition)
+          resizeObserver.observe(titleElement)
+        }
       }
-    }
 
-    updatePaginationPosition()
-    observeActiveTitle()
+      updatePaginationPosition()
+      observeActiveTitle()
 
-    const swiperInstance = (ref as React.RefObject<SwiperRef>).current?.swiper
-    if (swiperInstance) {
-      swiperInstance.on('slideChange', () => {
-        updatePaginationPosition()
-        observeActiveTitle()
-      })
-
-      swiperInstance.on('slideChangeTransitionEnd', () => {
-        updatePaginationPosition()
-      })
-    }
-
-    return () => {
-      resizeObserver?.disconnect()
+      const swiperInstance = (ref as React.RefObject<SwiperRef>).current?.swiper
       if (swiperInstance) {
-        swiperInstance.off('slideChange')
-        swiperInstance.off('slideChangeTransitionEnd')
+        swiperInstance.on('slideChange', () => {
+          updatePaginationPosition()
+          observeActiveTitle()
+        })
+
+        swiperInstance.on('slideChangeTransitionEnd', () => {
+          updatePaginationPosition()
+        })
       }
-    }
-  }, [showPagination, ref])
 
-  return (
-    <>
-      <Swiper
-        ref={ref}
-        spaceBetween={50}
-        slidesPerView={1}
-        onSlideChange={swiper => onSlideChange(swiper.activeIndex)}
-        pagination={showPagination ? { clickable: true } : false}
-        modules={showPagination ? [Pagination] : []}
-        className="relative h-full course__confirm-user-info__slider"
-        allowTouchMove={true}
-        touchEventsTarget="container"
-        nested={true}
-        touchRatio={0.5}
-      >
-        {slides.map((slide, idx) => {
-          const SlideComponent = slide.component
-          return (
-            <SwiperSlide key={slide.id || idx}>
-              <div className="flex flex-col h-full">
-                <SlideComponent
-                  slideIndex={idx}
-                  isActive={true}
-                  {...slide.props}
-                />
-              </div>
-            </SwiperSlide>
-          )
-        })}
-      </Swiper>
+      return () => {
+        resizeObserver?.disconnect()
+        if (swiperInstance) {
+          swiperInstance.off('slideChange')
+          swiperInstance.off('slideChangeTransitionEnd')
+        }
+      }
+    }, [showPagination, ref])
 
-      {showPagination && (
-        <style jsx global>{`
+    return (
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+      <div className="h-full" onKeyDown={handleKeyDown}>
+        <Swiper
+          ref={ref}
+          spaceBetween={50}
+          slidesPerView={1}
+          onSlideChange={swiper => onSlideChange(swiper.activeIndex)}
+          pagination={showPagination ? { clickable: true } : false}
+          modules={showPagination ? [Pagination] : []}
+          className="relative h-full course__confirm-user-info__slider"
+          allowTouchMove={true}
+          touchRatio={0.5}
+        >
+          {slides.map((slide, idx) => {
+            const SlideComponent = slide.component
+            const isActive = idx === currentIndex
+            return (
+              <SwiperSlide key={slide.id || idx}>
+                {/* The ref callback sets/removes the `inert` attribute imperatively.
+                  `inert` prevents the browser from focusing elements in off-screen
+                  slides, which would cause the virtual keyboard "Next" button to
+                  scroll Swiper and skip slides on mobile. */}
+                <div
+                  className="flex flex-col h-full"
+                  ref={el => {
+                    if (!el) return
+                    if (isActive) {
+                      el.removeAttribute('inert')
+                    } else {
+                      el.setAttribute('inert', '')
+                    }
+                  }}
+                >
+                  <SlideComponent
+                    slideIndex={idx}
+                    isActive={isActive}
+                    {...slide.props}
+                  />
+                </div>
+              </SwiperSlide>
+            )
+          })}
+        </Swiper>
+
+        {showPagination && (
+          <style jsx global>{`
             .course__confirm-user-info__slider .swiper-pagination {
               display: flex;
               justify-content: left;
@@ -151,9 +182,10 @@ export const ConfirmInscriptionSlider = forwardRef<
               width: 24px;
             }
           `}</style>
-      )}
-    </>
-  )
-})
+        )}
+      </div>
+    )
+  }
+)
 
 ConfirmInscriptionSlider.displayName = 'ConfirmInscriptionSlider'

--- a/src/app/(app)/(logged-in-out)/servicos/(servicos)/cursos/confirmar-informacoes/components/slides/custom-field-slide.tsx
+++ b/src/app/(app)/(logged-in-out)/servicos/(servicos)/cursos/confirmar-informacoes/components/slides/custom-field-slide.tsx
@@ -56,6 +56,7 @@ export function CustomFieldSlide({
           inputMode="email"
           placeholder="exemplo@email.com"
           className={inputClassName}
+          enterKeyHint="next"
         />
       )
     }
@@ -72,6 +73,7 @@ export function CustomFieldSlide({
               inputMode={fmt === 'number' ? 'numeric' : 'tel'}
               placeholder={PLACEHOLDER[fmt] ?? ''}
               className={inputClassName}
+              enterKeyHint="next"
             />
           )}
         />
@@ -89,6 +91,7 @@ export function CustomFieldSlide({
            focus-visible:ring-0 focus-visible:border-primary"
           rows={3}
           maxLength={50}
+          enterKeyHint="next"
         />
         <p className="text-muted-foreground text-sm">Limite de 50 caracteres</p>
       </div>


### PR DESCRIPTION
O botão de ação do teclado virtual ("Próximo"/"Ir") causava salto de slides no carrossel de informações complementares em dispositivos móveis.

Causa raiz: o Swiper renderiza todos os slides no DOM simultaneamente. Ao pressionar o botão do teclado, o browser movia o foco para o próximo elemento focalizável na ordem do DOM — que podia estar em um slide diferente. O browser então chamava scrollIntoView() nesse elemento e o Swiper interpretava o scroll como gesto de toque, pulando slides.

Correções aplicadas:

- Aplica o atributo HTML `inert` via ref callback em todos os slides inativos, tornando seus elementos não-focalizáveis e impedindo que o browser role até eles (correção principal)
- Adiciona handler onKeyDown no container do slider: intercepta Enter em inputs/textareas e chama handleNext() diretamente (melhora UX no Android)
- Adiciona enterKeyHint="next" nos campos de texto para exibir o label correto no teclado virtual
- Remove nested={true} (não há Swiper pai) e touchEventsTarget="container" (tornavam o Swiper mais sensível a eventos de scroll desnecessariamente)
- Corrige isActive que era hardcoded como true para todos os slides
- Passa currentIndex ao ConfirmInscriptionSlider (também em change-schedule-client.tsx)